### PR TITLE
Fix name of the opt used to grab x-ni-api-key

### DIFF
--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -184,7 +184,7 @@ class AsyncReqChannel:
         }
         if self.ttype == "tcp":
             # send NI API key for TCP transport
-            ret["ni-api-key"] = self.opts["ni_api_key"]
+            ret["ni-api-key"] = self.opts["ni-api-key"]
         if self.crypt == "aes":
             ret["id"] = self.opts["id"]
             ret["enc_algo"] = self.opts["encryption_algorithm"]
@@ -503,7 +503,7 @@ class AsyncPubChannel:
 
         if self.ttype == "tcp":
             # send NI API key for TCP transport
-            ret["ni-api-key"] = self.opts["ni_api_key"]
+            ret["ni-api-key"] = self.opts["ni-api-key"]
 
         return ret
 

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -184,7 +184,7 @@ class AsyncReqChannel:
         }
         if self.ttype == "tcp":
             # send NI API key for TCP transport
-            ret["x-ni-api-key"] = self.opts["x-ni-api-key"]
+            ret["x-ni-api-key"] = self.opts.get("x-ni-api-key")
         if self.crypt == "aes":
             ret["id"] = self.opts["id"]
             ret["enc_algo"] = self.opts["encryption_algorithm"]
@@ -503,7 +503,7 @@ class AsyncPubChannel:
 
         if self.ttype == "tcp":
             # send NI API key for TCP transport
-            ret["x-ni-api-key"] = self.opts["x-ni-api-key"]
+            ret["x-ni-api-key"] = self.opts.get("x-ni-api-key")
 
         return ret
 

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -184,7 +184,7 @@ class AsyncReqChannel:
         }
         if self.ttype == "tcp":
             # send NI API key for TCP transport
-            ret["ni-api-key"] = self.opts["ni-api-key"]
+            ret["x-ni-api-key"] = self.opts["x-ni-api-key"]
         if self.crypt == "aes":
             ret["id"] = self.opts["id"]
             ret["enc_algo"] = self.opts["encryption_algorithm"]
@@ -503,7 +503,7 @@ class AsyncPubChannel:
 
         if self.ttype == "tcp":
             # send NI API key for TCP transport
-            ret["ni-api-key"] = self.opts["ni-api-key"]
+            ret["x-ni-api-key"] = self.opts["x-ni-api-key"]
 
         return ret
 


### PR DESCRIPTION
In commit https://github.com/AlexDanDuna/salt/commit/f9f783df0ba59e3eebac3f9cff441d6a6fd6c937#diff-8a276cfe45c79e02fa75a4725a175a312707cac0234e711a7dcbcf7b8f11f11d:~:text=Commit-,f9f783d,-Browse%20files, I used wrong names for the dict keys referring to the `x-ni-api-key` (correct ones: https://github.com/ni/salt/blob/c4c662034de249841908e723da4d0ec2e907f2a2/salt/transport/tcp.py#L489).

Also, use `dict`'s `get` method, as that returns None, instead of yielding a key error, when the key does not exist.