### PR TITLE
Fix transport type check for TCP in client.py

### DIFF
--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -501,7 +501,7 @@ class AsyncPubChannel:
             "version": 3,
         }
 
-        if self.ttype == "tcp":
+        if self.transport.ttype == "tcp":
             # send NI API key for TCP transport
             ret["x-ni-api-key"] = self.opts.get("x-ni-api-key")
 


### PR DESCRIPTION
The class AsyncPubChannel has no `ttype` property, unlinke the class AsyncReqChannel, in the same file. This has been overlooked when cherry-picking the x-ni-api-key commit.