### PR TITLE
Adapt salt install scripts back to working with Python generated by relenv

### DIFF
--- a/pkg/windows/build.ps1
+++ b/pkg/windows/build.ps1
@@ -3,9 +3,12 @@
 Parent script that runs all other scripts required to build Salt
 
 .DESCRIPTION
-This script builds Python, Installs Salt, and runs Windows-specific postprocessing logic. It depends on the following Scripts
+This script Cleans, Installs Dependencies, Builds Python, Installs Salt,
+and builds the NullSoft Installer. It depends on the following Scripts
 and are called in this order:
 
+- clean_env.ps1
+- install_nsis.ps1
 - build_python.ps1
 - install_salt.ps1
 - build_pkg.ps1
@@ -14,7 +17,8 @@ and are called in this order:
 build.ps1
 
 .EXAMPLE
-build.ps1 -Version 3006 -PythonDir C:\Python310
+build.ps1 -Version 3005 -PythonVersion 3.10.9
+
 #>
 
 param(
@@ -26,13 +30,39 @@ param(
     [String] $Version,
 
     [Parameter(Mandatory=$false)]
+    [ValidateSet("x86", "x64", "amd64")]
+    [Alias("a")]
+    # The System Architecture to build. "x86" will build a 32-bit installer.
+    # "x64" will build a 64-bit installer. Default is: x64
+    $Architecture = "x64",
+
+    [Parameter(Mandatory=$false)]
+    [ValidatePattern("^\d{1,2}.\d{1,2}.\d{1,2}$")]
+    [Alias("p")]
+    # The version of Python to build/fetch. This is tied to the version of
+    # Relenv
+    [String] $PythonVersion,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("r")]
+    # The version of Relenv to install
+    [String] $RelenvVersion,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("b")]
+    # Build python from source instead of fetching a tarball
+    # Requires VC Build Tools
+    [Switch] $Build,
+
+    [Parameter(Mandatory=$false)]
     [Alias("c")]
     # Don't pretify the output of the Write-Result
     [Switch] $CICD,
-	
-	[Parameter(Mandatory=$false)]    
-    # Directory of the Python installation to use
-    [String] $PythonDir
+
+    [Parameter(Mandatory=$false)]
+    # Don't install/build python. It should already be installed
+    [Switch] $SkipInstall
+
 )
 
 #-------------------------------------------------------------------------------
@@ -51,6 +81,9 @@ $PROJECT_DIR    = $(git rev-parse --show-toplevel)
 if ( $Architecture -eq "amd64" ) {
   $Architecture = "x64"
 }
+
+# Environment variables
+$env:SALT_BUILD_ALL_BINS = 1 # this is necessary because salt builds no longer include salt-master and some other scripts on Windows
 
 #-------------------------------------------------------------------------------
 # Verify Salt and Version
@@ -72,33 +105,79 @@ if ( [String]::IsNullOrEmpty($Version) ) {
 }
 
 #-------------------------------------------------------------------------------
+# Verify Python and Relenv Versions
+#-------------------------------------------------------------------------------
+
+$yaml = Get-Content -Path "$PROJECT_DIR\cicd\shared-gh-workflows-context.yml"
+$dict_versions = @{}
+$dict_versions["python_version"]=($yaml | Select-String -Pattern "python_version: (.*)").matches.groups[1].Value.Trim("""")
+$dict_versions["relenv_version"]=($yaml | Select-String -Pattern "relenv_version: (.*)").matches.groups[1].Value.Trim("""")
+
+if ( [String]::IsNullOrEmpty($PythonVersion) ) {
+    $PythonVersion = $dict_versions["python_version"]
+    if ( [String]::IsNullOrEmpty($PythonVersion) ) {
+        Write-Host "Failed to load Python Version"
+        exit 1
+    }
+}
+
+if ( [String]::IsNullOrEmpty($RelenvVersion) ) {
+    $RelenvVersion = $dict_versions["relenv_version"]
+    if ( [String]::IsNullOrEmpty($RelenvVersion) ) {
+        Write-Host "Failed to load Relenv Version"
+        exit 1
+    }
+}
+
+#-------------------------------------------------------------------------------
 # Start the Script
 #-------------------------------------------------------------------------------
 
 Write-Host $("#" * 80)
 Write-Host "Build Salt Installer Packages" -ForegroundColor Cyan
 Write-Host "- Salt Version:   $Version"
+Write-Host "- Python Version: $PythonVersion"
+Write-Host "- Relenv Version: $RelenvVersion"
+Write-Host "- Architecture:   $Architecture"
 Write-Host $("v" * 80)
 
 #-------------------------------------------------------------------------------
-# Build Python
+# Install Visual Studio Build Tools
 #-------------------------------------------------------------------------------
 
 $KeywordArguments = @{}
-if ( $Build ) {
-	$KeywordArguments["Build"] = $false
-}
 if ( $CICD ) {
-	$KeywordArguments["CICD"] = $true
+    $KeywordArguments["CICD"] = $true
 }
-if ( $PythonDir ) {
-	$KeywordArguments["PythonDir"] = $PythonDir
+& "$SCRIPT_DIR\install_vs_buildtools.ps1" @KeywordArguments
+if ( ! $? ) {
+    Write-Host "Failed to install Visual Studio Build Tools"
+    exit 1
 }
 
-& "$SCRIPT_DIR\build_python.ps1" @KeywordArguments
-if ( ! $? ) {
-	Write-Host "Failed to build Python"
-	exit 1
+
+if ( ! $SkipInstall ) {
+  #-------------------------------------------------------------------------------
+  # Build Python
+  #-------------------------------------------------------------------------------
+
+  $KeywordArguments = @{
+      Version = $PythonVersion
+      Architecture = $Architecture
+      RelenvVersion = $RelenvVersion
+  }
+  if ( $Build ) {
+      $KeywordArguments["Build"] = $false
+  }
+  if ( $CICD ) {
+      $KeywordArguments["CICD"] = $true
+  }
+
+  & "$SCRIPT_DIR\build_python.ps1" @KeywordArguments
+  if ( ! $? ) {
+      Write-Host "Failed to build Python"
+      exit 1
+  }
 }
 
 #-------------------------------------------------------------------------------
@@ -112,7 +191,6 @@ if ( $CICD ) {
 if ( $SkipInstall ) {
     $KeywordArguments["SkipInstall"] = $true
 }
-
 $KeywordArguments["PKG"] = $true
 & "$SCRIPT_DIR\install_salt.ps1" @KeywordArguments
 if ( ! $? ) {

--- a/pkg/windows/build.ps1
+++ b/pkg/windows/build.ps1
@@ -82,9 +82,6 @@ if ( $Architecture -eq "amd64" ) {
   $Architecture = "x64"
 }
 
-# Environment variables
-$env:SALT_BUILD_ALL_BINS = 1 # this is necessary because salt builds no longer include salt-master and some other scripts on Windows
-
 #-------------------------------------------------------------------------------
 # Verify Salt and Version
 #-------------------------------------------------------------------------------
@@ -140,6 +137,34 @@ Write-Host "- Python Version: $PythonVersion"
 Write-Host "- Relenv Version: $RelenvVersion"
 Write-Host "- Architecture:   $Architecture"
 Write-Host $("v" * 80)
+
+#-------------------------------------------------------------------------------
+# Install NSIS
+#-------------------------------------------------------------------------------
+
+$KeywordArguments = @{}
+if ( $CICD ) {
+    $KeywordArguments["CICD"] = $true
+}
+& "$SCRIPT_DIR\install_nsis.ps1" @KeywordArguments
+if ( ! $? ) {
+    Write-Host "Failed to install NSIS"
+    exit 1
+}
+
+#-------------------------------------------------------------------------------
+# Install WIX
+#-------------------------------------------------------------------------------
+
+$KeywordArguments = @{}
+if ( $CICD ) {
+    $KeywordArguments["CICD"] = $true
+}
+& "$SCRIPT_DIR\install_wix.ps1" @KeywordArguments
+if ( ! $? ) {
+    Write-Host "Failed to install WIX"
+    exit 1
+}
 
 #-------------------------------------------------------------------------------
 # Install Visual Studio Build Tools
@@ -226,6 +251,17 @@ if ( $CICD ) {
 }
 
 & "$SCRIPT_DIR\nsis\build_pkg.ps1" @KeywordArguments
+
+if ( ! $? ) {
+    Write-Host "Failed to build NSIS package"
+    exit 1
+}
+
+#-------------------------------------------------------------------------------
+# Build MSI Package
+#-------------------------------------------------------------------------------
+
+& "$SCRIPT_DIR\msi\build_pkg.ps1" @KeywordArguments
 
 if ( ! $? ) {
     Write-Host "Failed to build NSIS package"

--- a/pkg/windows/build_python.ps1
+++ b/pkg/windows/build_python.ps1
@@ -47,9 +47,6 @@ param(
 
 )
 
-# Script Variables
-$PROJECT_DIR     = $(git rev-parse --show-toplevel)
-
 #-------------------------------------------------------------------------------
 # Script Preferences
 #-------------------------------------------------------------------------------
@@ -157,6 +154,21 @@ Write-Host "Creating Temporary PowerShell Profile: " -NoNewline
 Write-Result "Success" -ForegroundColor Green
 
 #-------------------------------------------------------------------------------
+# Make sure we're not in a virtual environment
+#-------------------------------------------------------------------------------
+if ( $env:VIRTUAL_ENV ) {
+    Write-Host "Deactivating virtual environment"
+    . deactivate
+    Write-Host $env:VIRTUAL_ENV
+    if ( $env:VIRTUAL_ENV ) {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    } else {
+        Write-Result "Success" -ForegroundColor Green
+    }
+}
+
+#-------------------------------------------------------------------------------
 # Script Variables
 #-------------------------------------------------------------------------------
 $SCRIPT_DIR   = (Get-ChildItem "$($myInvocation.MyCommand.Definition)").DirectoryName
@@ -174,6 +186,17 @@ if ( $Architecture -eq "x64" ) {
 #-------------------------------------------------------------------------------
 # Prepping Environment
 #-------------------------------------------------------------------------------
+if ( Test-Path -Path "$SCRIPT_DIR\venv" ) {
+    Write-Host "Removing virtual environment directory: " -NoNewline
+    Remove-Item -Path "$SCRIPT_DIR\venv" -Recurse -Force
+    if ( Test-Path -Path "$SCRIPT_DIR\venv" ) {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    } else {
+        Write-Result "Success" -ForegroundColor Green
+    }
+}
+
 if ( Test-Path -Path "$RELENV_DIR" ) {
     Write-Host "Removing existing relenv directory: " -NoNewline
     Remove-Item -Path "$RELENV_DIR" -Recurse -Force
@@ -194,6 +217,30 @@ if ( Test-Path -Path "$BUILD_DIR" ) {
     } else {
         Write-Result "Success" -ForegroundColor Green
     }
+}
+
+#-------------------------------------------------------------------------------
+# Setting Up Virtual Environment
+#-------------------------------------------------------------------------------
+Write-Host "Installing virtual environment: " -NoNewline
+Start-Process -FilePath "$SYS_PY_BIN" `
+              -ArgumentList "-m", "venv", "venv" `
+              -WorkingDirectory "$SCRIPT_DIR" `
+              -Wait -WindowStyle Hidden
+if ( Test-Path -Path "$SCRIPT_DIR\venv" ) {
+    Write-Result "Success" -ForegroundColor Green
+} else {
+    Write-Result "Failed"
+    exit 1
+}
+
+Write-Host "Activating virtual environment: " -NoNewline
+. "$SCRIPT_DIR\venv\Scripts\activate.ps1"
+if ( $env:VIRTUAL_ENV ) {
+    Write-Result "Success" -ForegroundColor Green
+} else {
+    Write-Result "Failed" -ForegroundColor Red
+    exit 1
 }
 
 #-------------------------------------------------------------------------------

--- a/pkg/windows/build_python.ps1
+++ b/pkg/windows/build_python.ps1
@@ -11,18 +11,44 @@ as created by the Python installer. This includes all header files, scripts,
 dlls, library files, and pip.
 
 .EXAMPLE
-build_python.ps1 -PythonDir C:\Python310
+build_python.ps1 -Version 3.10.9 -Architecture x86
 
 #>
 param(
-    [Parameter(Mandatory=$false)]    
-    # Directory of the Python installation to use
-    [String] $PythonDir,
-	
-	[Parameter(Mandatory=$false)]    
+    [Parameter(Mandatory=$false)]
+    [ValidatePattern("^\d{1,2}.\d{1,2}.\d{1,2}$")]
+    [Alias("v")]
+    # The version of python to build/fetch. This is tied to the version of
+    # Relenv
+    [String] $Version,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("r")]
+    # The version of Relenv to install
+    [String] $RelenvVersion,
+
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("x64", "x86", "amd64")]
+    [Alias("a")]
+    # The System Architecture to build. "x86" will build a 32-bit installer.
+    # "x64" will build a 64-bit installer. Default is: x64
+    [String] $Architecture = "x64",
+
+    [Parameter(Mandatory=$false)]
+    [Alias("b")]
+    # Build python from source instead of fetching a tarball
+    # Requires VC Build Tools
+    [Switch] $Build,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("c")]
     # Don't pretify the output of the Write-Result
     [Switch] $CICD
+
 )
+
+# Script Variables
+$PROJECT_DIR     = $(git rev-parse --show-toplevel)
 
 #-------------------------------------------------------------------------------
 # Script Preferences
@@ -49,10 +75,46 @@ function Write-Result($result, $ForegroundColor="Green") {
     }}
 
 #-------------------------------------------------------------------------------
+# Verify Python and Relenv Versions
+#-------------------------------------------------------------------------------
+
+$yaml = Get-Content -Path "$PROJECT_DIR\cicd\shared-gh-workflows-context.yml"
+$dict_versions = @{}
+$dict_versions["python_version"]=($yaml | Select-String -Pattern "python_version: (.*)").matches.groups[1].Value.Trim("""")
+$dict_versions["relenv_version"]=($yaml | Select-String -Pattern "relenv_version: (.*)").matches.groups[1].Value.Trim("""")
+
+if ( [String]::IsNullOrEmpty($Version) ) {
+    $Version = $dict_versions["python_version"]
+    if ( [String]::IsNullOrEmpty($Version) ) {
+        Write-Host "Failed to load Python Version"
+        exit 1
+    }
+}
+
+if ( [String]::IsNullOrEmpty($RelenvVersion) ) {
+    $RelenvVersion = $dict_versions["relenv_version"]
+    if ( [String]::IsNullOrEmpty($RelenvVersion) ) {
+        Write-Host "Failed to load Relenv Version"
+        exit 1
+    }
+}
+
+#-------------------------------------------------------------------------------
 # Start the Script
 #-------------------------------------------------------------------------------
 
-Write-Host "Running build python"
+Write-Host $("=" * 80)
+if ( $Build ) {
+    $SCRIPT_MSG = "Build Python with Relenv"
+} else {
+    $SCRIPT_MSG = "Fetch Python with Relenv"
+}
+Write-Host "$SCRIPT_MSG" -ForegroundColor Cyan
+Write-Host "- Python Version: $Version"
+Write-Host "- Relenv Version: $RelenvVersion"
+Write-Host "- Architecture:   $Architecture"
+Write-Host "- Build:          $Build"
+Write-Host $("-" * 80)
 
 #-------------------------------------------------------------------------------
 # Global Script Preferences
@@ -101,7 +163,7 @@ $SCRIPT_DIR   = (Get-ChildItem "$($myInvocation.MyCommand.Definition)").Director
 $BUILD_DIR    = "$SCRIPT_DIR\buildenv"
 $RELENV_DIR   = "${env:LOCALAPPDATA}\relenv"
 $SYS_PY_BIN   = (python -c "import sys; print(sys.executable)")
-$BLD_PY_BIN   = "$BUILD_DIR\python.exe"
+$BLD_PY_BIN   = "$BUILD_DIR\Scripts\python.exe"
 
 if ( $Architecture -eq "x64" ) {
     $ARCH         = "amd64"
@@ -109,17 +171,20 @@ if ( $Architecture -eq "x64" ) {
     $ARCH         = "x86"
 }
 
-if ( $PythonDir ) {
-	$PYTHON_DIR = $PythonDir
-} else {
-	# use System Python if no Python directory was specified
-	$PYTHON_DIR = (python -c "import sys, os; print(os.path.dirname(sys.executable))")
-}
-Write-Host "Using Python installation directory: " $PYTHON_DIR
-
 #-------------------------------------------------------------------------------
 # Prepping Environment
 #-------------------------------------------------------------------------------
+if ( Test-Path -Path "$RELENV_DIR" ) {
+    Write-Host "Removing existing relenv directory: " -NoNewline
+    Remove-Item -Path "$RELENV_DIR" -Recurse -Force
+    if ( Test-Path -Path "$RELENV_DIR" ) {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    } else {
+        Write-Result "Success" -ForegroundColor Green
+    }
+}
+
 if ( Test-Path -Path "$BUILD_DIR" ) {
     Write-Host "Removing existing build directory: " -NoNewline
     Remove-Item -Path "$BUILD_DIR" -Recurse -Force
@@ -132,10 +197,41 @@ if ( Test-Path -Path "$BUILD_DIR" ) {
 }
 
 #-------------------------------------------------------------------------------
-# Copying Python distribution to build directory
+# Installing Relenv
 #-------------------------------------------------------------------------------
-Write-Host "Copying Python distribution to build directory" -NoNewLine
-Copy-Item -Path $PYTHON_DIR -Destination $BUILD_DIR -Force -Recurse
+Write-Host "Installing Relenv ($RelenvVersion): " -NoNewLine
+pip install relenv==$RelenvVersion --disable-pip-version-check | Out-Null
+$output = pip list --disable-pip-version-check
+if ("relenv" -in $output.split()) {
+    Write-Result "Success" -ForegroundColor Green
+} else {
+    Write-Result "Failed" -ForegroundColor Red
+    exit 1
+}
+$env:RELENV_FETCH_VERSION=$RelenvVersion
+
+#-------------------------------------------------------------------------------
+# Building Python with Relenv
+#-------------------------------------------------------------------------------
+if ( $Build ) {
+    Write-Host "Building Python with Relenv (long-running): " -NoNewLine
+    $output = relenv build --clean --python $Version --arch $ARCH
+} else {
+    Write-Host "Fetching Python with Relenv: " -NoNewLine
+    relenv fetch --python $Version --arch $ARCH | Out-Null
+    if ( Test-Path -Path "$RELENV_DIR\build\$Version-$ARCH-win.tar.xz") {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+
+#-------------------------------------------------------------------------------
+# Extracting Python environment
+#-------------------------------------------------------------------------------
+Write-Host "Extracting Python environment: " -NoNewLine
+relenv create --python $Version --arch $ARCH "$BUILD_DIR"
 If ( Test-Path -Path "$BLD_PY_BIN" ) {
     Write-Result "Success" -ForegroundColor Green
 } else {

--- a/pkg/windows/install_salt.ps1
+++ b/pkg/windows/install_salt.ps1
@@ -71,7 +71,7 @@ if ( $BuildDir ) {
 }
 $SITE_PKGS_DIR = "$BUILD_DIR\Lib\site-packages"
 $SCRIPTS_DIR   = "$BUILD_DIR\Scripts"
-$PYTHON_BIN    = "$BUILD_DIR\python.exe"
+$PYTHON_BIN    = "$SCRIPTS_DIR\python.exe"
 $PY_VERSION    = [Version]((Get-Command $PYTHON_BIN).FileVersionInfo.ProductVersion)
 $PY_MAJOR_VERSION = "$($PY_VERSION.Major)"
 $PY_MINOR_VERSION = "$($PY_VERSION.Minor)"
@@ -81,9 +81,6 @@ $ARCH          = $(. $PYTHON_BIN -c "import platform; print(platform.architectur
 # Script Variables
 $PROJECT_DIR     = $(git rev-parse --show-toplevel)
 $SALT_DEPS       = "$PROJECT_DIR\requirements\static\pkg\py$PY_VERSION\windows.txt"
-
-# Environment variables
-$env:SALT_BUILD_ALL_BINS = 1 # this is necessary because salt builds no longer include salt-master and some other scripts on Windows
 
 if ( ! $SkipInstall ) {
   #-------------------------------------------------------------------------------
@@ -126,8 +123,8 @@ if ( ! $SkipInstall ) {
   # Installing dependencies
   #-------------------------------------------------------------------------------
   Write-Host "Installing dependencies: " -NoNewline
-  Start-Process -FilePath $PYTHON_BIN `
-                -ArgumentList "-m", "pip", "install", "-r", "$SALT_DEPS" `
+  Start-Process -FilePath $SCRIPTS_DIR\pip3.exe `
+                -ArgumentList "install", "-r", "$SALT_DEPS" `
                 -WorkingDirectory "$PROJECT_DIR" `
                 -Wait -WindowStyle Hidden
   if ( Test-Path -Path "$SCRIPTS_DIR\distro.exe" ) {
@@ -237,14 +234,14 @@ if ( ! $SkipInstall ) {
   }
   try {
       $env:RELENV_PIP_DIR = "yes"
-      Start-Process -FilePath $PYTHON_BIN `
-                "-m", "pip", "install", "$InstallPath" `
+      Start-Process -FilePath $SCRIPTS_DIR\pip3.exe `
+                -ArgumentList "install", $InstallPath `
                 -WorkingDirectory "$PROJECT_DIR" `
                 -Wait -WindowStyle Hidden
   } finally {
       Remove-Item env:\RELENV_PIP_DIR
   }
-  if ( Test-Path -Path "$SCRIPTS_DIR\salt-minion.exe" ) {
+  if ( Test-Path -Path "$BUILD_DIR\salt-minion.exe" ) {
       Write-Result "Success" -ForegroundColor Green
   } else {
       Write-Result "Failed" -ForegroundColor Red

--- a/pkg/windows/install_salt.ps1
+++ b/pkg/windows/install_salt.ps1
@@ -82,6 +82,9 @@ $ARCH          = $(. $PYTHON_BIN -c "import platform; print(platform.architectur
 $PROJECT_DIR     = $(git rev-parse --show-toplevel)
 $SALT_DEPS       = "$PROJECT_DIR\requirements\static\pkg\py$PY_VERSION\windows.txt"
 
+# Environment variables
+$env:SALT_BUILD_ALL_BINS = 1 # this is necessary because salt builds no longer include salt-master and some other scripts on Windows
+
 if ( ! $SkipInstall ) {
   #-------------------------------------------------------------------------------
   # Start the Script

--- a/pkg/windows/nsis/build_pkg.ps1
+++ b/pkg/windows/nsis/build_pkg.ps1
@@ -59,7 +59,7 @@ $INSTALLER_DIR  = "$SCRIPT_DIR\installer"
 $SCRIPTS_DIR    = "$BUILDENV_DIR\Scripts"
 $SITE_PKGS_DIR  = "$BUILDENV_DIR\Lib\site-packages"
 $BUILD_SALT_DIR = "$SITE_PKGS_DIR\salt"
-$PYTHON_BIN     = "$BUILDENV_DIR\python.exe"
+$PYTHON_BIN     = "$SCRIPTS_DIR\python.exe"
 $PY_VERSION     = [Version]((Get-Command $PYTHON_BIN).FileVersionInfo.ProductVersion)
 $PY_VERSION     = "$($PY_VERSION.Major).$($PY_VERSION.Minor)"
 $NSIS_BIN       = "$( ${env:ProgramFiles(x86)} )\NSIS\makensis.exe"
@@ -106,7 +106,7 @@ if ( Test-Path -Path "$PYTHON_BIN" ) {
 }
 
 Write-Host "Verifying Salt Installation: " -NoNewline
-if ( Test-Path -Path "$SCRIPTS_DIR\salt-minion.exe" ) {
+if ( Test-Path -Path "$BUILDENV_DIR\salt-minion.exe" ) {
     Write-Result "Success" -ForegroundColor Green
 } else {
     Write-Result "Failed" -ForegroundColor Red

--- a/pkg/windows/prep_salt.ps1
+++ b/pkg/windows/prep_salt.ps1
@@ -65,7 +65,7 @@ if ( $BuildDir ) {
 $SCRIPTS_DIR    = "$BUILD_DIR\Scripts"
 $BUILD_CONF_DIR = "$BUILD_DIR\configs"
 $SITE_PKGS_DIR  = "$BUILD_DIR\Lib\site-packages"
-$PYTHON_BIN     = "$BUILD_DIR\python.exe"
+$PYTHON_BIN     = "$SCRIPTS_DIR\python.exe"
 $PY_VERSION     = [Version]((Get-Command $PYTHON_BIN).FileVersionInfo.ProductVersion)
 $PY_VERSION     = "$($PY_VERSION.Major).$($PY_VERSION.Minor)"
 $ARCH           = $(. $PYTHON_BIN -c "import platform; print(platform.architecture()[0])")
@@ -100,7 +100,7 @@ if ( Test-Path -Path "$PYTHON_BIN" ) {
 }
 
 Write-Host "Verifying Salt Installation: " -NoNewline
-if ( Test-Path -Path "$SCRIPTS_DIR\salt-minion.exe" ) {
+if ( Test-Path -Path "$BUILD_DIR\salt-minion.exe" ) {
     Write-Result "Success" -ForegroundColor Green
 } else {
     Write-Result "Failed" -ForegroundColor Red

--- a/pkg/windows/runners/salt-api.bat
+++ b/pkg/windows/runners/salt-api.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-api
 
 :: Launch Script

--- a/pkg/windows/runners/salt-call.bat
+++ b/pkg/windows/runners/salt-call.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-call
 
 :: Launch Script

--- a/pkg/windows/runners/salt-cp.bat
+++ b/pkg/windows/runners/salt-cp.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-cp
 
 :: Launch Script

--- a/pkg/windows/runners/salt-key.bat
+++ b/pkg/windows/runners/salt-key.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-key
 
 :: Launch Script

--- a/pkg/windows/runners/salt-master.bat
+++ b/pkg/windows/runners/salt-master.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-master
 
 :: Launch Script

--- a/pkg/windows/runners/salt-minion-debug.bat
+++ b/pkg/windows/runners/salt-minion-debug.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-minion
 
 :: Stop the Salt Minion service

--- a/pkg/windows/runners/salt-minion.bat
+++ b/pkg/windows/runners/salt-minion.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-minion
 
 :: Launch Script

--- a/pkg/windows/runners/salt-run.bat
+++ b/pkg/windows/runners/salt-run.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-run
 
 :: Launch Script

--- a/pkg/windows/runners/salt.bat
+++ b/pkg/windows/runners/salt.bat
@@ -5,7 +5,7 @@
 :: Define Variables
 Set SaltDir=%~dp0
 Set SaltDir=%SaltDir:~0,-1%
-Set Python=%SaltDir%\bin\python.exe
+Set Python=%SaltDir%\bin\scripts\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt
 
 :: Launch Script


### PR DESCRIPTION
We initially modified the salt installer scripts to allow them to use our own Python export. Upon further investigation, this export seems to contain absolute paths, which may create issues down the road. I'm suggesting that we instead use `relenv`, as the main salt project does, to create a portable Python installation.

This PR reverts some the changes to the install scripts, while also adapting the *.bat files (which are used by some parts of SLS to call into salt) to the folder structure of the installation created by `relenv`.