### PR TITLE
Fix the publishing of periodic presence events

### DIFF
--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -890,12 +890,6 @@ class PubServerChannel:
         self.presence_events = presence_events
         self.event = salt.utils.event.get_event("master", opts=self.opts, listen=False)
 
-        if presence_events:
-            io_loop = salt.ext.tornado.ioloop.IOLoop.current()
-            io_loop.add_future(
-                self._send_presence_events(),
-                lambda f: True)
-
     def __getstate__(self):
         return {
             "opts": self.opts,
@@ -945,7 +939,7 @@ class PubServerChannel:
             salt.master.SMaster.secrets = secrets
         self.master_key = salt.crypt.MasterKeys(self.opts)
         self.transport.publish_daemon(
-            self.publish_payload, self.presence_callback, self.remove_presence_callback
+            self.publish_payload, self.presence_callback, self.remove_presence_callback, self.send_presence_events_callback
         )
 
     def presence_callback(self, subscriber, msg):
@@ -966,14 +960,16 @@ class PubServerChannel:
         self._remove_client_present(subscriber)
 
     @salt.ext.tornado.gen.coroutine
-    def _send_presence_events(self):
-        while True:
-            data = {'present': list(self.present.keys())}
-            self.event.fire_event(
-                data,
-                salt.utils.event.tagify('present', 'presence')
-            )
-            yield salt.ext.tornado.gen.sleep(60)
+    def send_presence_events_callback(self):
+        if self.presence_events:
+            while True:
+                log.info(f"[ALEX] _send_presence_events: PRESENT: {self.present} ; PRESENT.KEYS: {self.present.keys()}")
+                data = {'present': list(self.present.keys())}
+                self.event.fire_event(
+                    data,
+                    salt.utils.event.tagify('present', 'presence')
+                )
+                yield salt.ext.tornado.gen.sleep(60)
 
     def _add_client_present(self, client):
         id_ = client.id_

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -963,7 +963,6 @@ class PubServerChannel:
     def send_presence_events_callback(self):
         if self.presence_events:
             while True:
-                log.info(f"[ALEX] _send_presence_events: PRESENT: {self.present} ; PRESENT.KEYS: {self.present.keys()}")
                 data = {'present': list(self.present.keys())}
                 self.event.fire_event(
                     data,

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -814,7 +814,8 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
     """
 
     def __init__(
-        self, opts, io_loop=None, presence_callback=None, remove_presence_callback=None
+        self, opts, io_loop=None, presence_callback=None, remove_presence_callback=None,
+        send_presence_events_callback=None
     ):
         super().__init__(ssl_options=opts.get("ssl"))
         self.io_loop = io_loop
@@ -830,6 +831,10 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
             self.remove_presence_callback = remove_presence_callback
         else:
             self.remove_presence_callback = lambda subscriber: subscriber
+
+        if send_presence_events_callback:
+            self.send_presence_events_callback = send_presence_events_callback
+            self.io_loop.add_callback(self.send_presence_events_callback)
 
     def close(self):
         if self._closing:
@@ -940,6 +945,7 @@ class TCPPublishServer(salt.transport.base.DaemonizedPublishServer):
         publish_payload,
         presence_callback=None,
         remove_presence_callback=None,
+        send_presence_events_callback=None
     ):
         """
         Bind to the interface specified in the configuration file
@@ -954,6 +960,7 @@ class TCPPublishServer(salt.transport.base.DaemonizedPublishServer):
             io_loop=io_loop,
             presence_callback=presence_callback,
             remove_presence_callback=remove_presence_callback,
+            send_presence_events_callback=send_presence_events_callback
         )
         sock = _get_socket(self.opts)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
The publishing of periodic presence events was not linked to the correct IOLoop in cherry-pick https://github.com/AlexDanDuna/salt/commit/b2854264e0a2121833cd2cb35cd8708c4da890c6. This PR fixes the issue by making sure the publishing callback is attached to the proper IOLoop, instead of calling Tornado's current IOLoop.

In Salt 3000.2 (the Salt version that we're upgrading from), both the presence information and IOLoop are available in a single class.

Salt has reorganized its source code so that: 
- the presence information is available in `PubServerChannel` (under `channel/server.py`)
- `PubServerChannel` doesn't have access to an IOLoop
- an IOLoop is only created after the `pre_fork` method of this class is called, and classes that have access to the loop (`TCPPublishServer` and `PubServer`, under  `transport/tcp.py`) call back into this one via functions passed to the `_publish_daemon` function; this is why the initial cherry-pick, which was using Tornado's Current IOLoop from __init__, was wrong, as a new IOLoop is created and set as the current one after _publish_daemon is called
- we're therefore passing our periodic events sending function to `_publish_daemon` and making sure that `PubServer` will attach the function as an IOLoop callback
- an alternative would have been to attach the callback under `TCPPublishServer`, therefore avoiding having to alter `PubServer` as well, but it seemed better to do this under `PubServer`, since this is where other callbacks are attached to the IOLoop, whereas `TCPPublishServer` is creating the loop and passing it to `PubServer`.