### PR TITLE
Replace os.rename with os.replace when writing minion session files on the master to fix session file creation

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1576,7 +1576,7 @@ class Crypticle:
             os.close(fd)
             with salt.utils.files.fopen(tmp, "w") as fp:
                 fp.write(cls.generate_key_string(key_size))
-            os.rename(tmp, path)
+            os.replace(tmp, path)
 
     @classmethod
     def read_key(cls, path):


### PR DESCRIPTION
On windows, the Python's `os.rename` yields a FileAlreadyExists error when the destination passed to  `os.rename` already exists, unlike Linux, where the replace is performed with no issues. 

This leads to errors when using a Windows master, as can be seen here:
<img width="1985" height="459" alt="image" src="https://github.com/user-attachments/assets/da8abd28-a4d8-4904-a42f-aecefcb6188b" />

This PR replaces the call to `os.rename` to a call to `os.replace`.