### PR TITLE
Fix minion not reconnecting upon master machine restart due to improper exception handling

### DIFF
--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -361,6 +361,14 @@ class AsyncReqChannel:
             except Exception as exc:  # pylint: disable=broad-except
                 log.trace("Failed to send msg %r", exc)
                 if _try >= tries:
+                    if isinstance(exc, salt.ext.tornado.iostream.StreamClosedError):
+                        # Convert a tornado.iostream.StreamClosedError to a SaltClientError as
+                        # the StreamClosedError is not properly handled by callers (e.g. crypt.sign_in,
+                        # which was noticed to sometimes break the minion from reconnecting when this occurs, 
+                        # upon restarting a Windows master machine).
+                        # NOTE: Converting this particular exception to a SaltClientError was the behavior before 
+                        # https://github.com/saltstack/salt/pull/61468.
+                        raise SaltClientError("Connection to master lost") 
                     raise
                 else:
                     _try += 1

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -364,8 +364,9 @@ class AsyncReqChannel:
                     if isinstance(exc, salt.ext.tornado.iostream.StreamClosedError):
                         # Convert a tornado.iostream.StreamClosedError to a SaltClientError as
                         # the StreamClosedError is not properly handled by callers (e.g. crypt.sign_in,
-                        # which was noticed to sometimes break the minion from reconnecting when this occurs, 
-                        # upon restarting a Windows master machine).
+                        # which was noticed to sometimes break Windows minions from reconnecting, 
+                        # upon restarting the master machine. The issue seems to occur more consistently when using
+                        # a Windows master).
                         # NOTE: Converting this particular exception to a SaltClientError was the behavior before 
                         # https://github.com/saltstack/salt/pull/61468.
                         raise SaltClientError("Connection to master lost") 

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -363,7 +363,7 @@ class AsyncReqChannel:
                 if _try >= tries:
                     if isinstance(exc, salt.ext.tornado.iostream.StreamClosedError):
                         # Convert a tornado.iostream.StreamClosedError to a SaltClientError as
-                        # the StreamClosedError is not properly handled by callers (e.g. crypt.sign_in,
+                        # the StreamClosedError is not properly handled by callers (e.g. crypt._authenticate,
                         # which was noticed to sometimes break Windows minions from reconnecting, 
                         # upon restarting the master machine. The issue seems to occur more consistently when using
                         # a Windows master).

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -369,7 +369,7 @@ class AsyncReqChannel:
                         # a Windows master).
                         # NOTE: Converting this particular exception to a SaltClientError was the behavior before 
                         # https://github.com/saltstack/salt/pull/61468.
-                        raise SaltClientError("Connection to master lost") 
+                        raise salt.exceptions.SaltClientError("Connection to master lost") 
                     raise
                 else:
                     _try += 1


### PR DESCRIPTION
Convert a tornado.iostream.StreamClosedError to a SaltClientError as the StreamClosedError is not properly handled by callers (e.g. crypt._authenticate, which was noticed to sometimes break Windows minions from reconnecting,  upon restarting the master machine. The issue seems to occur more consistently when using a Windows master).


**NOTE:** Converting this particular exception to a SaltClientError was the behavior before https://github.com/saltstack/salt/pull/61468.

The error showing up on the minion when it stops attempting to reconnect to the master:
`2025-11-12 03:49:24,584 [tornado.application:640 ][ERROR   ][12180] Exception in callback functools.partial(<function wrap.<locals>.null_wrapper at 0x0000024D4D519240>, <salt.ext.tornado.concurrent.Future object at 0x0000024D4BF41330>)
Traceback (most recent call last):
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\ioloop.py", line 606, in _run_callback
    ret = callback()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\stack_context.py", line 278, in null_wrapper
    return fn(*args, **kwargs)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\ioloop.py", line 628, in _discard_future_result
    future.result()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\crypt.py", line 745, in _authenticate
    creds = yield self.sign_in(channel=channel)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\crypt.py", line 873, in sign_in
    payload = yield channel.send(sign_in_payload, tries=tries, timeout=timeout)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\channel\client.py", line 356, in send
    ret = yield self._uncrypted_transfer(load, timeout=timeout)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\channel\client.py", line 327, in _uncrypted_transfer
    ret = yield self.transport.send(
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\transport\tcp.py", line 1069, in send
    ret = yield self.message_client.send(load, timeout=timeout)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\transport\tcp.py", line 773, in send
    recv = yield future
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\transport\tcp.py", line 641, in _stream_return
    wire_bytes = yield self._stream.read_bytes(4096, partial=True)
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-minion\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
salt.ext.tornado.iostream.StreamClosedError: Stream is closed
2025-11-12 03:49:26,581 [salt.transport.tcp:614 ][WARNING ][12180] TCP Message Client encountered an exception while connecting to 10.94.121.74:4505: StreamClosedError('Stream is closed'), will reconnect in 1 seconds
2025-11-12 03:49:26,612 [salt.transport.tcp:614 ][WARNING ][12180] TCP Message Client encountered an exception while connecting to 10.94.121.74:4506: StreamClosedError('Stream is closed'), will reconnect in 1 seconds`