### PR TITLE
Fix iteration over clients to avoid races

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -910,7 +910,7 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
         if topic_list:
             for topic in topic_list:
                 sent = False
-                for client in self.clients:
+                for client in list(self.clients):
                     if topic == client.id_:
                         try:
                             # Write the packed str
@@ -922,7 +922,7 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
                 if not sent:
                     log.debug("Publish target %s not connected %r", topic, self.clients)
         else:
-            for client in self.clients:
+            for client in list(self.clients):
                 try:
                     # Write the packed str
                     yield client.stream.write(payload)


### PR DESCRIPTION
Convert self.clients to a list for safe iteration. This is already done on the saltstack 3007.x and master branches, but for some reason not on 3006.x, on which we are based.

Without this, errors such as this appear
2026-04-07 14:08:15,391 [tornado.application:640 ][ERROR   ][2336] Exception in callback functools.partial(<function wrap.<locals>.null_wrapper at 0x000001848DE22F80>, <salt.ext.tornado.concurrent.Future object at 0x00000184ABDE30D0>)
Traceback (most recent call last):
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\ioloop.py", line 606, in _run_callback
    ret = callback()
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\stack_context.py", line 278, in null_wrapper
    return fn(*args, **kwargs)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\ioloop.py", line 628, in _discard_future_result
    future.result()
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\channel\server.py", line 1030, in publish_payload
    ret = yield self.transport.publish_payload(payload)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\transport\tcp.py", line 1033, in publish_payload
    ret = yield self.pub_server.publish_payload(payload, *args)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\transport\tcp.py", line 925, in publish_payload
    for client in self.clients:
RuntimeError: Set changed size during iteration

### What does this PR do?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
